### PR TITLE
Adds thank_you form element for redirection to custom thank you page

### DIFF
--- a/mitlib-cf7-elements.php
+++ b/mitlib-cf7-elements.php
@@ -39,6 +39,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 function add_custom_elements() {
 	wpcf7_add_form_tag( 'authenticate', 'authenticate_handler' );
 	wpcf7_add_form_tag( array( 'select_dlc', 'select_dlc*' ), 'dlc_handler', array( 'name-attr' => true ) );
+	wpcf7_add_form_tag( 'thank_you', 'thank_you_handler', array( 'path-attr' => true ) );
 }
 add_action( 'wpcf7_init', 'add_custom_elements' );
 
@@ -104,5 +105,21 @@ function dlc_handler( $tag ) {
 	$field .= file_get_contents( plugin_dir_path( __FILE__ ) . 'templates/select_dlc.html' );
 	$field .= '</select>';
 	$field .= '</span>';
+	return $field;
+}
+
+/**
+ * Thank you page handler.
+ *
+ * This implements the redirect to a specified thank you page when present.
+ *
+ * @param object $tag A WPCF7_FormTag object.
+ */
+function thank_you_handler( $tag ) {
+	$field = '<script type="text/javascript">';
+	$field .= "  document.addEventListener( 'wpcf7mailsent', function( event ) {";
+	$field .= "    location = '" . $tag['values'][0] . "';";
+	$field .= '  }, false );';
+	$field .= '</script>';
 	return $field;
 }

--- a/mitlib-cf7-elements.php
+++ b/mitlib-cf7-elements.php
@@ -3,7 +3,7 @@
  * Plugin Name: MITlib CF7 Elements
  * Plugin URI: https://github.com/MITLibraries/mitlib-cf7-elements
  * Description: Adds custom form controls for CF7 needed by the MIT Libraries.
- * Version: 0.0.3
+ * Version: 1.0.0
  * Author: Matt Bernhardt
  * Author URI: https://github.com/matt-bernhardt
  * License: GPL2


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This adds a new custom form element for use within CF7: `[thank_you]`

Some forms we build will work fine with an AJAX-provided status message, directly on the form page. Others, however, have more robust post-submission communiation needs - which is where this element comes in.

The element takes one parameter, the URL to load upon successful form submission. The full invokation is then:
```
[thank_you "/forms-sandbox/thank-you/"]
```

#### Helpful background context (if appropriate)
Without this PR, you would need to write javascript in the form definition, something like this:
```
<script>
document.addEventListener( 'wpcf7mailsent', function( event ) {
    location = '/forms-sandbox/thank-you/';
}, false );
</script>
```
This is fine, but then means that every time a content editor changes the form there is a chance that they'll somehow mangle this code. By moving this to a custom form element, we can avoid that type of problem.

#### How can a reviewer manually see the effects of these changes?
See Matt for the URL for a demonstration form that implements this feature.

#### Screenshots (if appropriate)
Before this PR:
![image](https://user-images.githubusercontent.com/1403248/39941399-6ea6f1b2-552a-11e8-9d94-eb7ceb5c180f.png)

After:
![image](https://user-images.githubusercontent.com/1403248/39941442-91d05728-552a-11e8-952b-c62d99ab263b.png)

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
