### PR TITLE
Adds recipient validation, and improves readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,13 @@
 [![Code Climate](https://codeclimate.com/github/MITLibraries/mitlib-cf7-elements/badges/gpa.svg)](https://codeclimate.com/github/MITLibraries/mitlib-cf7-elements)
 [![Issue Count](https://codeclimate.com/github/MITLibraries/mitlib-cf7-elements/badges/issue_count.svg)](https://codeclimate.com/github/MITLibraries/mitlib-cf7-elements)
 
-This plugin provides two new field types to the Contact Forms 7 plugin:
+This plugin provides three new field types to the Contact Forms 7 plugin:
 
 1. An authenticate button that passes the user through Touchstone.
-2. A dropdown control that is populated with the list of departments, labs, and centers at MIT
+2. A dropdown control that is populated with the list of departments, labs, and centers at MIT.
+3. An option to send the user to a thank you page after form submission.
+
+Additionally, the plugin adds a validation step for select and radio fields to prevent form hijacking.
 
 ## Prerequisites
 
@@ -15,4 +18,6 @@ This plugin assumes that you have a WordPress site with [Contact Forms 7](https:
 
 ## Use
 
-To add these fields to your form, add `[authenticate]` or `[select_dlc]` to your form design as desired. If your form needs the DLC selection to be a required field, the plugin supports the `select_dlc*` designation.
+To add any provided fields to your form, add `[authenticate]`, `[select_dlc]`, or `[thank_you]` to your form design as desired. If your form needs the DLC selection to be a required field, the plugin supports the `select_dlc*` designation.
+
+The added validation step applies to all select and radio fields. No actions need be taken by form builders.

--- a/mitlib-cf7-elements.php
+++ b/mitlib-cf7-elements.php
@@ -3,7 +3,7 @@
  * Plugin Name: MITlib CF7 Elements
  * Plugin URI: https://github.com/MITLibraries/mitlib-cf7-elements
  * Description: Adds custom form controls for CF7 needed by the MIT Libraries.
- * Version: 1.0.0
+ * Version: 1.1.0
  * Author: Matt Bernhardt
  * Author URI: https://github.com/matt-bernhardt
  * License: GPL2
@@ -74,6 +74,29 @@ function validate_dlc_filter( $result, $tag ) {
 	}
 	return $result;
 }
+
+/**
+ * Implements custom validation for radio fields.
+ *
+ * @param object $result A WPCF7_Validation object.
+ * @param object $tag    A WPCF7_FormTag object.
+ * @link https://contactform7.com/2015/03/28/custom-validation/
+ * @link https://wordpress.org/support/topic/protection-against-form-hijacking/
+ */
+function validate_options( $result, $tag ) {
+	// Check if the field value is not empty.
+	if ( ! empty( $_POST[ $tag->name ] ) ) {
+		// Look up the received value in the array of expected values.
+		$value = sanitize_text_field( wp_unslash( $_POST[ $tag->name ] ) );
+		if ( ! in_array( $value, $tag->values ) ) {
+			$result->invalidate( $tag, 'Unexpected value received' );
+		}
+	}
+	return $result;
+}
+add_filter( 'wpcf7_validate_radio', 'validate_options', 20, 2 );
+add_filter( 'wpcf7_validate_select', 'validate_options', 20, 2 );
+add_filter( 'wpcf7_validate_select*', 'validate_options', 20, 2 );
 
 /**
  * Authenticate button handler.


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This adds a `validate_options()` function, which is used to filter all submissions of radio and select fields. It checks the received value against the array of options defined by the form builder, to make sure that the user hasn't hijacked the form to supply their own altered value.

This also updates the repo readme to describe this feature. It also adds the thank_you field that was added previously, but omitted from the readme.

#### Helpful background context (if appropriate)
The validation function takes in a WPCF7_FormTag element - an example is:

```
WPCF7_FormTag Object
(
    [type] => select
    [basetype] => select
    [name] => menu-242
    [options] => Array
        (
            [0] => include_blank
        )

    [raw_values] => Array
        (
            [0] => one
            [1] => two
            [2] => three
        )

    [values] => Array
        (
            [0] => one
            [1] => two
            [2] => three
        )

    [pipes] => WPCF7_Pipes Object
        (
            [pipes:WPCF7_Pipes:private] => Array
                (
                    [0] => WPCF7_Pipe Object
                        (
                            [before] => one
                            [after] => one
                        )

                    [1] => WPCF7_Pipe Object
                        (
                            [before] => two
                            [after] => two
                        )

                    [2] => WPCF7_Pipe Object
                        (
                            [before] => three
                            [after] => three
                        )

                )

        )

    [labels] => Array
        (
            [0] => one
            [1] => two
            [2] => three
        )

    [attr] => 
    [content] => 
)
```

#### How can a reviewer manually see the effects of these changes?
By the time this is reviewed, it will have been deployed to dev and test. See Matt for URLs to forms to use to check that the hijacking defense works.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/NTI-337

#### Screenshots (if appropriate)
Validation rejection message
![image](https://user-images.githubusercontent.com/1403248/40143034-4e78088e-5928-11e8-85c6-ac5ee4e5e8a6.png)

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
